### PR TITLE
Fix package installation by switching to hatchling build backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,20 @@ Give Claude Code, Codex, and Gemini CLI agents access to Jupyter servers + noteb
 ## Installation
 
 ```bash
+# Install from GitHub using uv
+uv add git+https://github.com/goodfire-ai/scribe.git
+```
+
+### Development Installation
+
+For local development with editable install:
+
+```bash
 # Clone the repository
 git clone https://github.com/goodfire-ai/scribe.git
 
-# Navigate to a project directory -- you can even use the scribe repo itself
-cd /path/to/your-project
-
-# [optional] initialize a virtual environment
-uv venv
-
-# Install scribe into your project's environment
-uv pip install -e /path/to/scribe/repo
+# From your project directory, install scribe in editable mode
+uv add --editable /path/to/scribe
 ```
 
 ## Usage  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,5 +19,6 @@ dependencies = [
 [project.scripts]
 scribe = "scribe.cli.cli:main"
 
-[tool.setuptools]
-packages = ["scribe"]
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
## Problem
Installing scribe as a package (e.g., `uv add git+https://github.com/goodfire-ai/scribe.git`) would fail with:
```
ModuleNotFoundError: No module named 'scribe.cli'
```

This occurred because subpackages (`scribe.cli`, `scribe.notebook`, `scribe.providers`) weren't being included in the built distribution. Editable installs (`uv pip install -e .`) worked fine since they reference the source directory directly.

## Solution
- Added `[build-system]` configuration with hatchling as the build backend
- Hatchling automatically discovers and includes all Python subpackages in the distribution
- Updated README installation instructions to use `uv add` as the default installation method

## Testing
Verified that `uv add git+<fork-url>@fix/package-installation` successfully installs scribe with all subpackages accessible, and the `scribe` CLI command works as expected.