### PR TITLE
Fix/claude code temp dir watcher

### DIFF
--- a/scribe/cli/commands.py
+++ b/scribe/cli/commands.py
@@ -67,7 +67,12 @@ def copilot_impl(args=None, provider_name: str = DEFAULT_PROVIDER, verbose=False
             # Add any additional args passed to scribe copilot
             if args:
                 cmd.extend(args)
-            subprocess.run(cmd)
+            try:
+                subprocess.run(cmd)
+            finally:
+                # Clean up session-specific config files
+                settings_file.unlink(missing_ok=True)
+                mcp_config_file.unlink(missing_ok=True)
         elif provider_name == "gemini":
             # Get the settings from the provider
             settings_content = get_gemini_copilot_settings(python_path)


### PR DESCRIPTION
Claude Code's file watcher scans the directory containing config files passed via --mcp-config or --settings. When these files are in /tmp/, the watcher encounters socket files (e.g., vscode-git-*.sock) that cannot be watched on macOS, causing EOPNOTSUPP errors. The root cause is a bug in claude code (https://github.com/anthropics/claude-code/issues/14438, https://github.com/anthropics/claude-code/issues/15112)

This fix moves config files from /tmp/ to ~/.scribe/sessions/ as a temporary workaround.

Feel free to merge this or wait for the claude bug to be fixed