### PR TITLE
Feature: Mult-kernel support for any installed and registered Jupyter kernel

### DIFF
--- a/scribe/notebook/notebook_sever_handlers.py
+++ b/scribe/notebook/notebook_sever_handlers.py
@@ -43,6 +43,7 @@ class StartSessionHandler(ScribeAPIHandler):
                 fork_prev_notebook=data.get(
                     "fork_prev_notebook", True
                 ),  # Default to True for backward compatibility
+                kernel_name=data.get("kernel_name", "python3"),
             )
 
             # Add server URL and token to response
@@ -53,7 +54,7 @@ class StartSessionHandler(ScribeAPIHandler):
             result["vscode_url"] = (
                 f"http://localhost:{self.scribe_app.port}/?token={self.scribe_app.token}"
             )
-            result["kernel_name"] = result.pop("kernel_display_name", "")
+            result["kernel_display_name"] = result.pop("kernel_display_name", "")
             result["status"] = "started"
 
             self.finish(json.dumps(result))


### PR DESCRIPTION
Overall purpose is to allow the tool to handle any Jupyter kernel not just Python. Lots of good visualisation and high-throughput sequencing packages are written in R under the BioConductor project. Working autonomously with them would be a good unlock.

1. `get_notebook_metadata_for_kernel` replaces the previous approach of hardcoding Python 3.11 metadata in new sessions. It queries the Jupyter's KernelSpecManager. If the language model fails to infer the correct kernel name, the function returns the registered kernels, allowing the language model to pick the right one on the next turn.
2. `kernel_name` parameter for HTTP handler and server, MCP tool parameters
3. `kernel_name` and `kernel_display_name` (label for the session) are now separate in API responses. 

Still defaults to Python so backwards compatible. Default MCP tool request launches Python notebook. 

Tested on IRkernel, Julia and Python.

Of course, open to any suggestions for improvement.