### PR TITLE
Add real-time collaboration (RTC) support via jupyter-collaboration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "psutil>=7.0.0",
     "python-dotenv>=1.1.1",
     "requests>=2.32.4",
+    "jupyter-collaboration>=4.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This change allows watching Scribe's work live.

When Scribe creates a new cell, it will automatically appear in VSCode or a web browser that has the notebook open.

When Scribe runs a cell, a comment saying `#RUNNING THIS CELL` will appear at the top of that cell, until it finishes running.

If `jupyter-collaboration` is not installed, the standard File I/O will be used as fallback.

Questions: should this be an optional dependency?

